### PR TITLE
Improve chat input textarea with auto-grow and UI refinements

### DIFF
--- a/src/ui/ChatContainer.svelte
+++ b/src/ui/ChatContainer.svelte
@@ -135,6 +135,7 @@
     if (!text) return;
 
     inputText = "";
+    resetHeight();
 
     if (askUserResolve) {
       addUserMessage(text);
@@ -155,6 +156,17 @@
       e.preventDefault();
       handleSend();
     }
+  }
+
+  function autoGrow(): void {
+    if (!textareaEl) return;
+    textareaEl.style.height = "auto";
+    textareaEl.style.height = Math.min(textareaEl.scrollHeight, 150) + "px";
+  }
+
+  function resetHeight(): void {
+    if (!textareaEl) return;
+    textareaEl.style.height = "auto";
   }
 
   // Render markdown into a DOM node using Obsidian's renderer
@@ -271,6 +283,7 @@
       disabled={!inputEnabled}
       rows="1"
       onkeydown={handleKeydown}
+      oninput={autoGrow}
     ></textarea>
     <button
       class="ochat-send-btn"
@@ -472,11 +485,11 @@
   .ochat-input-bar {
     display: flex;
     align-items: flex-end;
-    gap: 6px;
-    padding: 6px 8px;
-    padding-bottom: calc(6px + env(safe-area-inset-bottom, 0px));
+    gap: 8px;
+    padding: 8px 12px;
+    padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     border-top: 1px solid var(--background-modifier-border);
-    background: transparent;
+    background: var(--background-primary);
     flex-shrink: 0;
   }
 
@@ -484,8 +497,8 @@
     flex: 1;
     resize: none;
     border: 1.5px solid var(--background-modifier-border-hover, var(--background-modifier-border));
-    border-radius: 18px;
-    padding: 6px 14px;
+    border-radius: 20px;
+    padding: 8px 16px;
     font-size: var(--font-ui-medium);
     font-family: var(--font-interface);
     background-color: var(--background-secondary);
@@ -507,10 +520,10 @@
   }
 
   .ochat-send-btn {
-    width: 32px;
-    height: 32px;
-    min-width: 32px;
-    min-height: 32px;
+    width: 34px;
+    height: 34px;
+    min-width: 34px;
+    min-height: 34px;
     padding: 0;
     border: none;
     border-radius: 50%;
@@ -522,7 +535,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin-bottom: 2px;
+    margin-bottom: 1px;
   }
 
   .ochat-send-btn:hover {
@@ -595,8 +608,23 @@
       max-width: 95%;
     }
 
+    .ochat-input-bar {
+      gap: 10px;
+      padding: 10px 12px;
+      padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
+    }
+
     .ochat-input {
-      font-size: 16px;
+      font-size: 16px; /* Prevents iOS zoom on focus */
+      padding: 10px 16px;
+      border-radius: 22px;
+    }
+
+    .ochat-send-btn {
+      width: 36px;
+      height: 36px;
+      min-width: 36px;
+      min-height: 36px;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
Enhanced the chat input experience by implementing auto-growing textarea functionality and refining the input bar styling for better visual consistency and usability across desktop and mobile devices.

## Key Changes
- **Auto-grow textarea**: Added `autoGrow()` function that dynamically adjusts textarea height based on content (capped at 150px) and `resetHeight()` to reset height after message submission
- **Input handling**: Connected `oninput` event to trigger auto-grow behavior as user types
- **Input bar styling**: Updated padding and gap values (6px → 8px/10px) and changed background from transparent to `var(--background-primary)` for better visual definition
- **Input field refinements**: 
  - Increased border-radius from 18px to 20px (22px on mobile)
  - Adjusted padding from 6px 14px to 8px 16px (10px 16px on mobile)
- **Send button sizing**: Increased dimensions from 32px to 34px (36px on mobile) for better touch targets
- **Mobile optimizations**: Added dedicated mobile media query styles with adjusted spacing and larger button size; added comment about 16px font preventing iOS zoom on focus

## Implementation Details
- The textarea height resets immediately after message submission to provide visual feedback
- The auto-grow function uses `scrollHeight` to measure content and applies a 150px maximum to prevent excessive growth
- Mobile styles ensure adequate spacing and touch-friendly button sizes for smaller screens

https://claude.ai/code/session_01V2UjLZTxsvbLcq46mDGLNQ