### PR TITLE
Add tools, persistence, stop button, and UX fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,11 @@ npm run svelte-check   # Svelte check
 | list_files | `vault.getFiles()` | Capped at 100 results |
 | rename_file | `fileManager.renameFile()` | Updates all links |
 | delete_file | `vault.trash()` | Respects user trash setting |
+| open_document | `workspace.getLeaf().openFile()` | Opens file in editor |
+| get_properties | `metadataCache.getFileCache()` | Reads YAML frontmatter |
+| set_properties | `fileManager.processFrontMatter()` | Safe YAML merge/remove |
+| get_backlinks | `metadataCache.resolvedLinks` | Finds linking notes |
+| get_current_datetime | `Date` | User's locale and timezone |
 | ask_user | UI callback | Pauses agent loop |
 
 ## Debug

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ That's it. Two providers. The best models. Fetch the full model list from the AP
 
 ## What the AI can do
 
-The chat assistant has 9 tools that map directly to Obsidian's Vault API:
+The chat assistant has 14 tools that map directly to Obsidian's Vault API:
 
 - **read_document** / **read_file**: Read any note in your vault
 - **edit_document**: Find-and-replace, insert, or replace content
@@ -28,6 +28,11 @@ The chat assistant has 9 tools that map directly to Obsidian's Vault API:
 - **rename_file**: Rename or move files (updates all links)
 - **delete_file**: Move files to trash
 - **list_files**: Browse vault structure
+- **open_document**: Navigate to a file in the editor
+- **get_properties**: Read YAML frontmatter as structured data
+- **set_properties**: Update frontmatter properties (uses Obsidian's native API)
+- **get_backlinks**: Find all notes that link to a given document
+- **get_current_datetime**: Get the current date and time in the user's locale
 - **ask_user**: Ask you a question when something is ambiguous
 
 The AI reads before it edits, prefers surgical find-and-replace over full rewrites, and acts on your confirmations without re-asking.
@@ -82,7 +87,7 @@ Select text in a note, right-click, and choose "Send selection to Chat". The sel
 |----------|-----|
 | Two providers only | Simplicity. Anthropic and OpenAI cover the best models. |
 | No streaming | Obsidian's `requestUrl()` doesn't support it. Required for mobile. |
-| No conversation persistence | Notes are the artifact, not chat logs. Chat persists in memory during the session. |
+| Conversation persistence | Chat history survives Obsidian restarts. Stored locally in `chat-state.json`, never synced. |
 | No vault indexing | Linear search capped at results limit. Avoids mobile memory issues. |
 | Svelte 5 UI | Compiles away to vanilla JS. Reactive state without React's runtime overhead. |
 | Right sidebar on mobile | Slides in from the edge, keeping your document underneath. |

--- a/manifest.json
+++ b/manifest.json
@@ -1,1 +1,1 @@
-{"id":"obsidian-chat","name":"Obsidian Chat","version":"1.0.2","minAppVersion":"1.7.0","description":"Agentic AI chat assistant that reads, edits, and creates notes through natural conversation","author":"Omar Shahine","isDesktopOnly":false}
+{"id":"obsidian-chat","name":"Obsidian Chat","version":"1.1.0","minAppVersion":"1.7.0","description":"Agentic AI chat assistant that reads, edits, and creates notes through natural conversation","author":"Omar Shahine","isDesktopOnly":false}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-chat",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "node esbuild.config.mjs",

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -64,6 +64,16 @@ export class AgentLoop {
     clearOpenAIState();
   }
 
+  /** Export API messages for persistence */
+  exportMessages(): UnifiedMessage[] {
+    return this.messages;
+  }
+
+  /** Restore API messages from persistence */
+  importMessages(messages: UnifiedMessage[]): void {
+    this.messages = messages;
+  }
+
   /** Export the full conversation as a readable markdown transcript */
   exportTranscript(): string {
     const systemPrompt = buildSystemPrompt();

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -11,9 +11,9 @@ const STATIC_PROMPT = `You are Obsidian Chat, an AI assistant embedded in Obsidi
 - Always read a document before editing it. Never guess at content.
 - Prefer find_replace over replace_all to make surgical edits.
 - When find_replace fails, read the document again to get the exact text.
-- In Obsidian, the filename IS the title. Never add an H1 heading that duplicates it. Use H2 as the top-level heading within document body content.
-- When writing into an Untitled document, ALWAYS rename it first using rename_file to give it a descriptive title that reflects the content. Then write the body starting at H2.
-- When creating new files, choose a descriptive filename (the title) and a sensible path based on vault structure.
+- CRITICAL: In Obsidian, the filename IS the title (displayed as an inline H1). NEVER write an H1 heading (# Title) in document content. Start body content at H2 (##) or plain text. This applies to create_file, edit_document, and any content you write.
+- When writing into an Untitled document, ALWAYS rename it first using rename_file to give it a descriptive title that reflects the content. Then write the body starting at H2 or plain text.
+- When creating new files, choose a descriptive filename (the title) and a sensible path based on vault structure. The filename alone serves as the title.
 - Keep responses concise. The user is often on mobile.
 - For multi-step edits, explain your plan briefly before starting.
 - If a search returns no results, try alternative queries or ask the user.

--- a/src/api/anthropic.ts
+++ b/src/api/anthropic.ts
@@ -81,22 +81,34 @@ export async function sendAnthropicMessage(
     body.tools = apiTools;
   }
 
-  const response = await requestUrl({
-    url: ANTHROPIC_API_URL,
-    method: "POST",
-    headers: {
-      "x-api-key": settings.apiKey,
-      "anthropic-version": "2023-06-01",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
+  let response;
+  try {
+    response = await requestUrl({
+      url: ANTHROPIC_API_URL,
+      method: "POST",
+      headers: {
+        "x-api-key": settings.apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+      throw: false,
+    });
+  } catch (e: unknown) {
+    // requestUrl throws on network errors; extract API details if available
+    const err = e as { status?: number; json?: { error?: { message?: string } } };
+    const apiMsg = err.json?.error?.message;
+    if (apiMsg) {
+      throw new Error(`Anthropic API error (${err.status}): ${apiMsg}`);
+    }
+    throw e;
+  }
 
   if (response.status !== 200) {
     const errorText = typeof response.json?.error?.message === "string"
       ? response.json.error.message
       : `HTTP ${response.status}`;
-    throw new Error(`Anthropic API error: ${errorText}`);
+    throw new Error(`Anthropic API error (${response.status}): ${errorText}`);
   }
 
   const data = response.json;
@@ -115,7 +127,7 @@ export async function sendAnthropicMessage(
 // ─── Format Conversions ─────────────────────────────────────────────────────
 
 interface AnthropicContentBlock {
-  type: "text" | "tool_use" | "web_search_tool_result" | "thinking";
+  type: "text" | "tool_use" | "web_search_tool_result" | "server_tool_use" | "thinking";
   text?: string;
   thinking?: string;
   id?: string;
@@ -148,7 +160,7 @@ function toAnthropicMessage(msg: UnifiedMessage): Record<string, unknown> {
       };
     }
     return { type: "text", text: block.text };
-  });
+  }).filter((b) => !(b.type === "text" && !b.text));
 
   return { role: msg.role, content: blocks };
 }
@@ -169,8 +181,12 @@ function fromAnthropicBlock(block: AnthropicContentBlock): ContentBlock | null {
       .join("\n\n");
     return { type: "text", text: formatted };
   }
-  // Thinking blocks are internal reasoning; don't show to user
-  if (block.type === "thinking") {
+  // Thinking and server_tool_use blocks are internal; don't surface to user
+  if (block.type === "thinking" || block.type === "server_tool_use") {
+    return null;
+  }
+  // Skip blocks with no text content (safety net)
+  if (!block.text) {
     return null;
   }
   return { type: "text", text: block.text };

--- a/src/api/openai.ts
+++ b/src/api/openai.ts
@@ -84,6 +84,7 @@ export async function sendOpenAIMessage(
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
+      throw: false,
     });
   } catch (e: unknown) {
     const err = e as Record<string, unknown>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
 } from "obsidian";
 import type { ChatSettings, SelectionScope } from "./types";
 import { DEFAULT_SETTINGS } from "./types";
-import { ChatSettingTab } from "./settings";
+import { ChatSettingTab, getModelDisplayName } from "./settings";
 import { ObsidianChatView, VIEW_TYPE_CHAT } from "./ui/chat-view";
 import { AgentLoop } from "./agent/loop";
 
@@ -25,6 +25,9 @@ export default class ChatPlugin extends Plugin {
     await this.loadSettings();
 
     this.agent = new AgentLoop(this.app, this.settings);
+
+    // Restore persisted chat history
+    await this.loadChatHistory();
 
     this.addSettingTab(new ChatSettingTab(this.app, this));
 
@@ -128,7 +131,8 @@ export default class ChatPlugin extends Plugin {
     );
   }
 
-  onunload(): void {
+  async onunload(): Promise<void> {
+    await this.saveChatHistory();
     this.app.workspace.detachLeavesOfType(VIEW_TYPE_CHAT);
   }
 
@@ -240,6 +244,40 @@ export default class ChatPlugin extends Plugin {
     }
   }
 
+  // ─── Chat history persistence ─────────────────────────────────────────
+
+  async saveChatHistory(): Promise<void> {
+    try {
+      const state = {
+        chatHistory: this.chatHistory.slice(-100), // Cap at 100 UI messages
+        agentMessages: this.agent.exportMessages().slice(-80), // Cap at 80 API messages
+      };
+      await this.app.vault.adapter.write(
+        ".obsidian/plugins/obsidian-chat/chat-state.json",
+        JSON.stringify(state)
+      );
+    } catch {
+      // Persistence is best-effort
+    }
+  }
+
+  private async loadChatHistory(): Promise<void> {
+    try {
+      const raw = await this.app.vault.adapter.read(
+        ".obsidian/plugins/obsidian-chat/chat-state.json"
+      );
+      const state = JSON.parse(raw);
+      if (Array.isArray(state.chatHistory)) {
+        this.chatHistory = state.chatHistory;
+      }
+      if (Array.isArray(state.agentMessages)) {
+        this.agent.importMessages(state.agentMessages);
+      }
+    } catch {
+      // No saved state or parse error — start fresh
+    }
+  }
+
   // ─── Settings persistence ────────────────────────────────────────────
 
   async loadSettings(): Promise<void> {
@@ -262,6 +300,11 @@ export default class ChatPlugin extends Plugin {
     // Save all other settings to data.json (syncs), but strip the API key
     const toSave = { ...this.settings, apiKey: "" };
     await this.saveData(toSave);
+
+    // Update the chat view header with the new model name
+    this.getChatView()?.updateModel(
+      getModelDisplayName(this.settings.provider, this.settings.model)
+    );
   }
 
   /** Load the correct API key when provider changes */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,14 @@ const FALLBACK_MODELS: Record<string, ModelOption[]> = {
 // Cache fetched models per provider so they survive tab re-opens
 const modelCache = new Map<string, ModelOption[]>();
 
+/** Resolve a model ID to its display name */
+export function getModelDisplayName(provider: string, modelId: string): string {
+  const cached = modelCache.get(provider);
+  const models = cached || FALLBACK_MODELS[provider] || [];
+  const match = models.find((m) => m.value === modelId);
+  return match?.label || modelId;
+}
+
 // ─── Settings Tab ───────────────────────────────────────────────────────────
 
 export class ChatSettingTab extends PluginSettingTab {

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -384,61 +384,15 @@ async function setProperties(
     return { result: input.path ? `File not found: ${input.path}` : "No active document open.", isError: true };
   }
 
-  await app.vault.process(file, (data) => {
-    const fmEnd = findFrontmatterEnd(data);
-
-    // Parse existing frontmatter
-    let existing: Record<string, unknown> = {};
-    let body: string;
-
-    if (fmEnd !== -1) {
-      const fmBlock = data.substring(3, fmEnd - 3).trim();
-      // Simple YAML key-value parser for frontmatter
-      for (const line of fmBlock.split("\n")) {
-        const colonIdx = line.indexOf(":");
-        if (colonIdx === -1) continue;
-        const key = line.substring(0, colonIdx).trim();
-        let value: unknown = line.substring(colonIdx + 1).trim();
-        // Handle arrays on the same line: tags: [a, b]
-        if (typeof value === "string" && value.startsWith("[") && value.endsWith("]")) {
-          value = value.slice(1, -1).split(",").map((s: string) => s.trim()).filter(Boolean);
-        } else if (value === "true") value = true;
-        else if (value === "false") value = false;
-        else if (value === "" || value === "null") value = null;
-        else if (!isNaN(Number(value))) value = Number(value);
-        existing[key] = value;
-      }
-      body = data.substring(fmEnd);
-    } else {
-      body = data;
-    }
-
-    // Merge: null values remove keys
+  // Use Obsidian's built-in processFrontMatter for safe YAML handling
+  await app.fileManager.processFrontMatter(file, (frontmatter) => {
     for (const [key, value] of Object.entries(props)) {
       if (value === null) {
-        delete existing[key];
+        delete frontmatter[key];
       } else {
-        existing[key] = value;
+        frontmatter[key] = value;
       }
     }
-
-    // Serialize back to YAML
-    const yamlLines: string[] = [];
-    for (const [key, value] of Object.entries(existing)) {
-      if (Array.isArray(value)) {
-        yamlLines.push(`${key}: [${value.join(", ")}]`);
-      } else if (typeof value === "string" && (value.includes(":") || value.includes("#") || value.includes("'"))) {
-        yamlLines.push(`${key}: "${value}"`);
-      } else {
-        yamlLines.push(`${key}: ${value}`);
-      }
-    }
-
-    if (yamlLines.length === 0) {
-      return body.startsWith("\n") ? body.substring(1) : body;
-    }
-
-    return `---\n${yamlLines.join("\n")}\n---${body.startsWith("\n") ? "" : "\n"}${body}`;
   });
 
   const setKeys = Object.entries(props).filter(([, v]) => v !== null).map(([k]) => k);
@@ -483,7 +437,7 @@ async function getBacklinks(
 function getCurrentDatetime(): ToolResult {
   const now = new Date();
   const iso = now.toISOString();
-  const local = now.toLocaleString("en-US", {
+  const local = now.toLocaleString(undefined, {
     weekday: "long",
     year: "numeric",
     month: "long",

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -36,6 +36,16 @@ export async function executeTool(
         return await renameFile(app, input);
       case "delete_file":
         return await deleteFile(app, input);
+      case "get_properties":
+        return await getProperties(app, input);
+      case "set_properties":
+        return await setProperties(app, input);
+      case "get_backlinks":
+        return await getBacklinks(app, input);
+      case "get_current_datetime":
+        return getCurrentDatetime();
+      case "open_document":
+        return await openDocument(app, input);
       case "ask_user":
         return await askUser(input, onAskUser);
       default:
@@ -335,6 +345,180 @@ async function deleteFile(
   // vault.trash() respects user's trash setting (.trash or system trash)
   await app.vault.trash(file, true);
   return { result: `Moved ${path} to trash.`, isError: false };
+}
+
+async function getProperties(
+  app: App,
+  input: Record<string, unknown>
+): Promise<ToolResult> {
+  const file = resolveFile(app, input.path as string | undefined);
+  if (!file) {
+    return { result: input.path ? `File not found: ${input.path}` : "No active document open.", isError: true };
+  }
+
+  const cache = app.metadataCache.getFileCache(file);
+  const frontmatter = cache?.frontmatter;
+
+  if (!frontmatter) {
+    return { result: `No frontmatter properties found in ${file.path}.`, isError: false };
+  }
+
+  // Remove the position metadata that Obsidian adds internally
+  const clean = { ...frontmatter };
+  delete clean.position;
+
+  return { result: JSON.stringify(clean, null, 2), isError: false };
+}
+
+async function setProperties(
+  app: App,
+  input: Record<string, unknown>
+): Promise<ToolResult> {
+  const props = input.properties as Record<string, unknown>;
+  if (!props || typeof props !== "object") {
+    return { result: "'properties' parameter must be an object.", isError: true };
+  }
+
+  const file = resolveFile(app, input.path as string | undefined);
+  if (!file) {
+    return { result: input.path ? `File not found: ${input.path}` : "No active document open.", isError: true };
+  }
+
+  await app.vault.process(file, (data) => {
+    const fmEnd = findFrontmatterEnd(data);
+
+    // Parse existing frontmatter
+    let existing: Record<string, unknown> = {};
+    let body: string;
+
+    if (fmEnd !== -1) {
+      const fmBlock = data.substring(3, fmEnd - 3).trim();
+      // Simple YAML key-value parser for frontmatter
+      for (const line of fmBlock.split("\n")) {
+        const colonIdx = line.indexOf(":");
+        if (colonIdx === -1) continue;
+        const key = line.substring(0, colonIdx).trim();
+        let value: unknown = line.substring(colonIdx + 1).trim();
+        // Handle arrays on the same line: tags: [a, b]
+        if (typeof value === "string" && value.startsWith("[") && value.endsWith("]")) {
+          value = value.slice(1, -1).split(",").map((s: string) => s.trim()).filter(Boolean);
+        } else if (value === "true") value = true;
+        else if (value === "false") value = false;
+        else if (value === "" || value === "null") value = null;
+        else if (!isNaN(Number(value))) value = Number(value);
+        existing[key] = value;
+      }
+      body = data.substring(fmEnd);
+    } else {
+      body = data;
+    }
+
+    // Merge: null values remove keys
+    for (const [key, value] of Object.entries(props)) {
+      if (value === null) {
+        delete existing[key];
+      } else {
+        existing[key] = value;
+      }
+    }
+
+    // Serialize back to YAML
+    const yamlLines: string[] = [];
+    for (const [key, value] of Object.entries(existing)) {
+      if (Array.isArray(value)) {
+        yamlLines.push(`${key}: [${value.join(", ")}]`);
+      } else if (typeof value === "string" && (value.includes(":") || value.includes("#") || value.includes("'"))) {
+        yamlLines.push(`${key}: "${value}"`);
+      } else {
+        yamlLines.push(`${key}: ${value}`);
+      }
+    }
+
+    if (yamlLines.length === 0) {
+      return body.startsWith("\n") ? body.substring(1) : body;
+    }
+
+    return `---\n${yamlLines.join("\n")}\n---${body.startsWith("\n") ? "" : "\n"}${body}`;
+  });
+
+  const setKeys = Object.entries(props).filter(([, v]) => v !== null).map(([k]) => k);
+  const removedKeys = Object.entries(props).filter(([, v]) => v === null).map(([k]) => k);
+  const parts: string[] = [];
+  if (setKeys.length > 0) parts.push(`Set: ${setKeys.join(", ")}`);
+  if (removedKeys.length > 0) parts.push(`Removed: ${removedKeys.join(", ")}`);
+
+  return { result: `Updated properties in ${file.path}. ${parts.join(". ")}.`, isError: false };
+}
+
+async function getBacklinks(
+  app: App,
+  input: Record<string, unknown>
+): Promise<ToolResult> {
+  const file = resolveFile(app, input.path as string | undefined);
+  if (!file) {
+    return { result: input.path ? `File not found: ${input.path}` : "No active document open.", isError: true };
+  }
+
+  // resolvedLinks maps: source path -> { target path -> link count }
+  const allLinks = app.metadataCache.resolvedLinks;
+  const backlinks: string[] = [];
+
+  for (const [sourcePath, targets] of Object.entries(allLinks)) {
+    if (targets[file.path]) {
+      backlinks.push(sourcePath);
+    }
+  }
+
+  if (backlinks.length === 0) {
+    return { result: `No backlinks found for ${file.path}.`, isError: false };
+  }
+
+  backlinks.sort();
+  return {
+    result: `${backlinks.length} note(s) link to ${file.path}:\n${backlinks.map((p) => `- ${p}`).join("\n")}`,
+    isError: false,
+  };
+}
+
+function getCurrentDatetime(): ToolResult {
+  const now = new Date();
+  const iso = now.toISOString();
+  const local = now.toLocaleString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  });
+  const dateOnly = now.toISOString().split("T")[0]; // YYYY-MM-DD for daily notes
+
+  return {
+    result: `Local: ${local}\nISO: ${iso}\nDate: ${dateOnly}`,
+    isError: false,
+  };
+}
+
+async function openDocument(
+  app: App,
+  input: Record<string, unknown>
+): Promise<ToolResult> {
+  const path = input.path as string;
+  if (!path) {
+    return { result: "'path' parameter is required.", isError: true };
+  }
+
+  const file = app.vault.getFileByPath(normalizePath(path));
+  if (!file) {
+    return { result: `File not found: ${path}`, isError: true };
+  }
+
+  // Open in the most recent non-chat leaf so it doesn't replace the sidebar
+  const leaf = app.workspace.getLeaf(false);
+  await leaf.openFile(file);
+  return { result: `Opened ${file.path}.`, isError: false };
 }
 
 async function askUser(

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -92,7 +92,7 @@ export const TOOL_DEFINITIONS: UnifiedToolDef[] = [
   },
   {
     name: "create_file",
-    description: "Create a new file in the vault. Fails if the file already exists.",
+    description: "Create a new file in the vault. Fails if the file already exists. IMPORTANT: The filename is the title in Obsidian, so never start content with an H1 heading that repeats the filename.",
     inputSchema: {
       type: "object",
       properties: {
@@ -153,6 +153,80 @@ export const TOOL_DEFINITIONS: UnifiedToolDef[] = [
         path: {
           type: "string",
           description: "Path of the file to delete relative to vault root.",
+        },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "get_properties",
+    description:
+      "Read the YAML frontmatter properties of a markdown document as structured data. Returns tags, aliases, and all custom properties.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the document. Omit to use the active document.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "set_properties",
+    description:
+      "Set or update YAML frontmatter properties on a markdown document. Merges with existing properties. Set a value to null to remove a property.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the document. Omit to use the active document.",
+        },
+        properties: {
+          type: "object",
+          description: "Key-value pairs to set in the frontmatter. Arrays (like tags) are supported. Set a value to null to remove that property.",
+        },
+      },
+      required: ["properties"],
+    },
+  },
+  {
+    name: "get_backlinks",
+    description:
+      "Find all notes in the vault that link to a given document. Uses Obsidian's metadata cache for fast lookups.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the document. Omit to use the active document.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "get_current_datetime",
+    description:
+      "Get the current date and time in the user's local timezone. Useful for daily notes, journaling, scheduling, or any time-aware task.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: "open_document",
+    description:
+      "Open a document in the Obsidian editor. Use this when the user wants to navigate to, view, or open a specific file.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the file relative to vault root.",
         },
       },
       required: ["path"],

--- a/src/ui/ChatContainer.svelte
+++ b/src/ui/ChatContainer.svelte
@@ -19,10 +19,12 @@
     model: string;
     onSend: (text: string, selection: SelectionScope | null) => void;
     onClear: () => void;
+    onStop: () => void;
   }
 
-  let { app, component, provider, model, onSend, onClear }: Props = $props();
+  let { app, component, provider, model, onSend, onClear, onStop }: Props = $props();
 
+  let displayModel = $state("");
   let messages = $state<ChatMessage[]>([]);
   let inputText = $state("");
   let inputEnabled = $state(true);
@@ -36,6 +38,11 @@
 
   // ask_user support
   let askUserResolve: ((value: string) => void) | null = $state(null);
+
+  // Sync model prop to local state (also updateable via setModel)
+  $effect(() => {
+    displayModel = model;
+  });
 
   // Auto-scroll when messages change
   $effect(() => {
@@ -115,6 +122,11 @@
     textareaEl?.focus();
   }
 
+  /** Update the model display name in the header */
+  export function setModel(name: string): void {
+    displayModel = name;
+  }
+
   /** Set the selection scope (shows pill in UI) */
   export function setSelection(sel: SelectionScope): void {
     selection = sel;
@@ -163,7 +175,7 @@
   function autoGrow(): void {
     if (!textareaEl) return;
     textareaEl.style.height = "auto";
-    textareaEl.style.height = Math.min(textareaEl.scrollHeight, 150) + "px";
+    textareaEl.style.height = Math.min(textareaEl.scrollHeight, 300) + "px";
   }
 
   function resetHeight(): void {
@@ -202,7 +214,7 @@
   <div class="ochat-header">
     <div class="ochat-header-left">
       <span class="ochat-header-title">Chat</span>
-      <span class="ochat-header-model">{model || "No model"}</span>
+      <span class="ochat-header-model">{displayModel || "No model"}</span>
     </div>
     <button class="ochat-clear-btn" onclick={onClear}>Clear</button>
   </div>
@@ -290,14 +302,23 @@
       onkeydown={handleKeydown}
       oninput={autoGrow}
     ></textarea>
-    <button
-      class="ochat-send-btn"
-      disabled={!inputEnabled}
-      onclick={handleSend}
-      aria-label="Send message"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"></line><polyline points="5 12 12 5 19 12"></polyline></svg>
-    </button>
+    {#if inputEnabled}
+      <button
+        class="ochat-send-btn"
+        onclick={handleSend}
+        aria-label="Send message"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"></line><polyline points="5 12 12 5 19 12"></polyline></svg>
+      </button>
+    {:else}
+      <button
+        class="ochat-send-btn ochat-stop-btn"
+        onclick={onStop}
+        aria-label="Stop generation"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none"><rect x="4" y="4" width="16" height="16" rx="2"></rect></svg>
+      </button>
+    {/if}
   </div>
 </div>
 
@@ -361,6 +382,8 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   .ochat-msg {
@@ -369,6 +392,8 @@
     border-radius: var(--radius-m);
     line-height: 1.5;
     word-wrap: break-word;
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   .ochat-user-msg {
@@ -505,7 +530,7 @@
     padding: 8px 12px;
     padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     border-top: 1px solid var(--background-modifier-border);
-    background: var(--background-primary);
+    background: transparent;
     flex-shrink: 0;
   }
 
@@ -520,7 +545,7 @@
     background-color: var(--background-secondary);
     color: var(--text-normal);
     line-height: 1.4;
-    max-height: 150px;
+    max-height: 300px;
     overflow-y: auto;
     box-shadow: none;
   }
@@ -561,6 +586,15 @@
   .ochat-send-btn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+
+  .ochat-stop-btn {
+    background-color: var(--text-error);
+  }
+
+  .ochat-stop-btn:hover {
+    background-color: var(--text-error);
+    opacity: 0.85;
   }
 
   /* ─── Selection Pill ─────────────────────────────────────────────────── */

--- a/src/ui/chat-view.ts
+++ b/src/ui/chat-view.ts
@@ -3,6 +3,7 @@ import { mount, unmount } from "svelte";
 import type ChatPlugin from "../main";
 import ChatContainer from "./ChatContainer.svelte";
 import type { ToolResult, SelectionScope } from "../types";
+import { getModelDisplayName } from "../settings";
 
 export const VIEW_TYPE_CHAT = "ochat-view";
 
@@ -45,10 +46,11 @@ export class ObsidianChatView extends ItemView {
         app: this.app,
         component: this,
         provider: this.plugin.settings.provider,
-        model: this.plugin.settings.model,
+        model: getModelDisplayName(this.plugin.settings.provider, this.plugin.settings.model),
         onSend: (text: string, selection: SelectionScope | null) =>
           this.handleUserMessage(text, selection),
         onClear: () => this.handleClear(),
+        onStop: () => this.handleStop(),
       },
     });
 
@@ -102,6 +104,11 @@ export class ObsidianChatView extends ItemView {
   /** Focus the input */
   focus(): void {
     this.chatContainer?.focus();
+  }
+
+  /** Update the model display name in the header */
+  updateModel(name: string): void {
+    this.chatContainer?.setModel(name);
   }
 
   /** Clear conversation */
@@ -173,6 +180,19 @@ export class ObsidianChatView extends ItemView {
       this.running = false;
       chat.setInputEnabled(true);
       chat.focus();
+      // Persist after each turn
+      this.plugin.saveChatHistory();
+    }
+  }
+
+  private handleStop(): void {
+    this.plugin.agent.abort();
+    this.running = false;
+    const chat = this.chatContainer;
+    if (chat) {
+      chat.hideThinking();
+      chat.setInputEnabled(true);
+      chat.focus();
     }
   }
 
@@ -183,5 +203,7 @@ export class ObsidianChatView extends ItemView {
     this.chatContainer?.clearMessages();
     this.running = false;
     this.chatContainer?.setInputEnabled(true);
+    // Clear persisted state
+    this.plugin.saveChatHistory();
   }
 }

--- a/src/ui/chat-view.ts
+++ b/src/ui/chat-view.ts
@@ -194,6 +194,7 @@ export class ObsidianChatView extends ItemView {
       chat.setInputEnabled(true);
       chat.focus();
     }
+    this.plugin.saveChatHistory();
   }
 
   private handleClear(): void {


### PR DESCRIPTION
## Summary

- **5 new tools**: `get_properties`, `set_properties`, `get_backlinks`, `get_current_datetime`, `open_document` for richer vault interaction
- **Chat persistence**: Conversations survive Obsidian restarts via `chat-state.json` (both UI history and API context)
- **Stop button**: Send button becomes a red stop icon during generation, aborts the agent loop
- **Web search fix**: Handle `server_tool_use` blocks from Anthropic to prevent 400 errors on follow-up turns
- **API error details**: Surface real error messages instead of generic "Request failed, status 400"
- **UX polish**: Text selection in messages, transparent input bar background, larger textarea (300px), model display name in header with reactive updates

## Test plan

- [ ] Verify new tools work: ask model to get properties, set a tag, find backlinks, get current time, open a document
- [ ] Test chat persistence: send messages, quit Obsidian, reopen — chat should restore
- [ ] Test stop button: send a message, tap stop while thinking — should abort and re-enable input
- [ ] Test web search: enable web search, ask a question, then follow up — should not 400
- [ ] Test model display: change model in settings — header should update immediately
- [ ] Verify input bar has no double border on light and dark themes
- [ ] Verify text is selectable in chat messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)