### PR TITLE
ci: add Dependabot npm coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+# Monthly and grouped on purpose: ungrouped weekly updates across this fleet
+# would be dozens of PRs a week. One PR per group per month is something a
+# person can actually read.
+#
+# No github-actions entry: this repo has no .github/workflows, so the entry
+# would match nothing. Add one alongside the first workflow.
+updates:
+  # ⚠️ Without this entry Dependabot never looks at package-lock.json at all,
+  # and security advisories accumulate forever with nothing opening a PR.
+  #
+  # No `production` group: every dependency here is a devDependency (svelte,
+  # esbuild, obsidian, typescript, @types/node). Add one with the first
+  # runtime dependency.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      # ⚠️ Security updates are NOT grouped by default, so three advisories in
+      # one lockfile get three PRs that all edit it. Merging any one
+      # invalidates the other two, `@dependabot recreate` rebuilds them, and
+      # the next merge breaks them again -- a loop this fleet actually hit on
+      # Lobster, findmy-cli and openclaw-parcel. This group ends it.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      # typescript moves ahead of everything built on its API, so a TS major
+      # bundled into the dev group takes the healthy updates down with it.
+      # On its own it fails alone and visibly instead.
+      typescript:
+        patterns:
+          - "typescript"
+      types:
+        patterns:
+          - "@types/*"
+      development:
+        dependency-type: development
+        exclude-patterns:
+          - "typescript"
+          - "@types/*"
+    commit-message:
+      prefix: deps


### PR DESCRIPTION
This repo had no `.github/dependabot.yml` at all, so its `package-lock.json` was invisible to Dependabot — security advisories accumulated with nothing ever opening a PR. This was the meta-cause behind today's fleet-wide alert audit.

## Directory registered

| Directory | Lock type |
|---|---|
| `/` | `package-lock.json` |

Verified against the git tree — that is the only lockfile in the repo.

## Why the `security` group

Security updates are ungrouped by default, so three advisories in one lockfile produce three PRs that all edit that lockfile. Merging any one invalidates the other two, `@dependabot recreate` rebuilds them, and the next merge re-breaks them. That loop actually hit Lobster, findmy-cli and openclaw-parcel in this fleet. `applies-to: security-updates` with `patterns: ["*"]` collapses it to one PR.

## Deliberately omitted

- **`github-actions` entry** — this repo has no `.github/workflows`, so it would match nothing. A comment says to add it alongside the first workflow.
- **`production` group** — the `dependencies` object is empty; svelte, esbuild, obsidian, typescript and @types/node are all devDependencies. A comment says to add it with the first runtime dependency.
- **eslint group** — no eslint, `@eslint/*` or `typescript-eslint` here.
- **`ignore` blocks** — nothing here peer-caps a major. An unjustified ignore would suppress a legitimate upgrade forever.

`typescript` gets its own group so a TS major fails alone and visibly rather than dragging the healthy dev updates down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDD6P9ft7DNNbrXpNWvCsk