### PR TITLE
deps: decline TypeScript 7, manage actions, pin their SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,20 @@ version: 2
 # Monthly and grouped on purpose: ungrouped weekly updates across this fleet
 # would be dozens of PRs a week. One PR per group per month is something a
 # person can actually read.
-#
-# No github-actions entry: this repo has no .github/workflows, so the entry
-# would match nothing. Add one alongside the first workflow.
 updates:
+  # CI workflows exist now, so their actions are managed here too. Pinned to
+  # commit SHAs in the workflow; Dependabot rewrites the SHA and the trailing
+  # version comment together.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: deps
+
   # ⚠️ Without this entry Dependabot never looks at package-lock.json at all,
   # and security advisories accumulate forever with nothing opening a PR.
   #
@@ -42,3 +52,15 @@ updates:
           - "@types/*"
     commit-message:
       prefix: deps
+    ignore:
+      # TypeScript 7 is blocked upstream, not by anything in this repo.
+      # svelte-check peers `typescript@^5.0.0 || ^6.0.0` -- still true on its
+      # newest release, 4.7.6 -- so `npm ci` dies with ERESOLVE before a single
+      # file is checked. That is exactly what PR #12 hit.
+      #
+      # Scoped to >=7 rather than to majors on purpose: svelte-check accepts
+      # TypeScript 6, so that bump should still be offered. Drop this entry
+      # when svelte-check widens its peer range to 7, and check that first
+      # rather than assuming this repo's own code is the blocker.
+      - dependency-name: "typescript"
+        versions: [">=7"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       matrix:
         check: [build, svelte-check]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7
         with:
           # The bundle is es2022 CJS for Obsidian's Electron renderer, and
           # manifest.json sets isDesktopOnly: false, so it also runs in the mobile


### PR DESCRIPTION
#12 (typescript 5.9.3 → 7.0.2) failed both checks. The cause is upstream, not this repo's code:

```
npm error peer typescript@"^5.0.0 || ^6.0.0" from svelte-check@4.7.6
npm error Conflicting peer dependency: typescript@6.0.3
```

`svelte-check` still peers `^5 || ^6` on its newest release (4.7.6, checked against the registry), so `npm ci` dies with `ERESOLVE` before a single file is checked.

**Scoped the ignore to `>=7`, not to majors.** svelte-check *does* accept TypeScript 6 — npm's own error names 6.0.3 as the resolvable version — so a blanket major ignore would have silently declined a bump that works. Drop the entry when svelte-check widens its peer range.

Also noticed the config still claimed this repo has no `.github/workflows`. It has one now, so I added the `github-actions` ecosystem and pinned both actions to commit SHAs, matching the rest of the fleet.

Closing #12 in favour of this.