### PR TITLE
fix: drop dead baseUrl from tsconfig, unblocking TypeScript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
#15 (typescript 5.9.3 → 6.0.3) failed both checks with an unhelpful `[svelte-preprocess] Encountered type error`. The real cause is further down the log:

```
Warn: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
```

TypeScript 6 deprecates `baseUrl`, and svelte-preprocess promotes that deprecation to a hard error.

`baseUrl` is dead config here — no `paths` map, no bare imports in `src/`. It was doing nothing except blocking the upgrade. Same finding as the sibling `obsidian-share` plugin.

Verified both directions rather than assumed:
- On the current **5.9.3**, removing it is a no-op: `npm run build` passes, svelte-check reports **0 errors**.
- On **6.0.3** installed locally, both now pass — where before the removal they failed.

The `>=7` ignore stays. TypeScript 7 is blocked separately by svelte-check's own peer range (`^5.0.0 || ^6.0.0`), which is upstream's to fix.

Once this lands, #15 should go green on a rebase.