### PR TITLE
fix: reject edit_document calls with no content

### DIFF
--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -103,13 +103,22 @@ async function editDocument(
   input: Record<string, unknown>
 ): Promise<ToolResult> {
   const operation = input.operation as string;
-  const content = input.content as string;
+  const content = input.content as string | undefined;
   const find = input.find as string | undefined;
   const position = input.position as string | undefined;
 
   const file = resolveFile(app, input.path as string | undefined);
   if (!file) {
     return { result: input.path ? `File not found: ${input.path}` : "No active document open.", isError: true };
+  }
+
+  // `content` is schema-required, but the model can still omit it, and all three
+  // operations write it. Reject rather than coerce: the concatenations below
+  // splice the literal string "undefined" into the note, and defaulting to ""
+  // would blank the file outright on replace_all. Test for undefined, not
+  // falsiness — `content: ""` legitimately deletes the found text.
+  if (content === undefined) {
+    return { result: "'content' parameter is required.", isError: true };
   }
 
   switch (operation) {


### PR DESCRIPTION
Found this while reading through the tool executor. `edit_document` casts `content` straight to `string`, so if a model leaves it out, the undefined value reaches the write path with nothing checking it.

`content` is in the schema's `required` list, so this shouldn't happen often, but models do drop required params, and all three operations write it.

What happens today:

- `find_replace`: `data.substring(0, idx) + content + data.substring(...)` puts the literal text `undefined` into the note, and the tool still returns success. So neither the user nor the model sees that anything went wrong.
- `insert`: same concatenation, same result.
- `replace_all`: passes `undefined` to `vault.modify()`.

The first two are the ones that bother me. A note gets corrupted, and it's reported as a successful edit.

I went with rejecting the call rather than defaulting `content` to `""`. Coercing to empty would swap the corruption for data loss, since `replace_all` with empty content blanks the whole file. An `isError` result is also something the agent loop can recover from, and it matches how the function already guards a missing `find` or `position`.

The check is `content === undefined` rather than falsiness, since `content: ""` is a legitimate way to delete the found text.

## Repro

Call `edit_document` with `find` but no `content`:

```json
{ "path": "Note.md", "operation": "find_replace", "find": "hello" }
```

Before: `hello` becomes `undefined` in the note, and the tool reports success.
After: `'content' parameter is required.`

## Checks

`npx tsc --noEmit` and `npm run build` both pass. There's no test harness in the repo, so I verified this by reading the three write paths rather than with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
